### PR TITLE
adds yargs for more flexible cli support

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -2,10 +2,31 @@
 
 var path      = require("path")
   , fs        = require("fs")
-  , jsome     = require("../script")
-  , filePath  = process.argv.slice(2).shift() || '';
+  , jsome     = require("../script");
 
-jsome.params.colored = true;
+var argv = require('yargs')
+  .usage('Usage: $0 [options] <file>')
+  .option('c',{
+    alias: 'colors',
+    default: true,
+    describe: 'color the output',
+    type: 'boolean'
+  })
+  .option('l',{
+    alias: 'levels',
+    default: false,
+    describe: 'show indentation levels',
+    type: 'boolean'
+  })
+  .example('$0 -cl /some/dir/file.json', 'print out the contents of file.json in color displaying indentation levels')
+  .example('$0 -c false -l /some/dir/file.json', 'print out the contents of file.json with no color but display indentation levels')
+  .help('h')
+  .argv;
+
+jsome.params.colored = argv.c;
+jsome.level.show     = argv.l;
+
+var filePath = argv._[0] || '';
 
 fs.exists(path.resolve(filePath), function (exists) {
   if(!exists) return jsome({error : "File doesn't exists"});
@@ -13,4 +34,4 @@ fs.exists(path.resolve(filePath), function (exists) {
     if(error) return jsome ({error : error.message});
     jsome.parse(jsonString.toString());
   });
-})
+});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "homepage": "https://github.com/Javascipt/Jsome#readme",
   "dependencies": {
     "chalk": "^1.1.1",
-    "json-stringify-safe": "^5.0.1"
+    "json-stringify-safe": "^5.0.1",
+    "yargs": "^3.29.0"
   },
   "bin": {
     "jsome": "./bin/cli.js"


### PR DESCRIPTION
- using yargs to handle cli args
- now support -l which you can use to show indentation levels
- prints usage and help

Could extend this further with additional cli params. I just added the two most obvious ones for now, the one I really wanted was the indentation level, but it at least establishes the pattern.
