### PR TITLE
Add getColoredString

### DIFF
--- a/script.js
+++ b/script.js
@@ -26,27 +26,27 @@ var colors = {
 
 
 module.exports = (function () {
-  
+
   function jsome (json, callBack) {
     return jsome.parse(stringify(json), callBack);
   }
-  
+
   jsome.colors  = colors;
   jsome.level   = level;
   jsome.params  = params;
-  
+
   var generator = require("./lib/generator").setJsomeRef(jsome)
     , stringify = require('json-stringify-safe');
-  
+
   jsome.parse = function (jsonString, callBack) {
     var json = JSON.parse(jsonString);
-    
+
     if (!jsome.params.async) {
       var output = generator.gen(json, jsome.level.start);
       if(Array.isArray(output)) {
         console.log.apply(console, output);
       } else {
-        console.log(output); 
+        console.log(output);
       }
     } else {
       setTimeout(function () {
@@ -54,11 +54,24 @@ module.exports = (function () {
         callBack && callBack();
       });
     }
-    
+
     return json;
   }
-  
-  
+
+  jsome.getColoredString = function(jsonString, callBack){
+    var json = JSON.parse(stringify(jsonString));
+    if (!jsome.params.async) {
+      var output = generator.gen(json, jsome.level.start);
+      return output
+    } else {
+      setTimeout(function () {
+        var output = generator.gen(json, jsome.level.start)
+        callBack && callBack(output);
+      });
+    }
+  }
+
+
   return jsome;
-  
+
 })();


### PR DESCRIPTION
Adds a `jsome.getColoredString(obj, cb)` method which will just return the colored, formatted, string. This is useful when you want to control when/how it's printed, rather than jsome printing it for you; for example as part of the prettyPrint function of winston logger