### PR TITLE
Allow lintable JSON output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,3 @@ node_js:
   - '4'
 before_script: npm link
 script: jsome package.json
-after_script: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ node_js:
   - '4'
 before_script: npm link
 script: jsome package.json
+after_script: npm test

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The options available are :
 - `-c`: to enable or disable colors (defualt value: true)
 - `-l`: to enable or disable levels (default value: false)
 - `-s`: to specify the number of tabulation spaces (default value: 2)
+- `-r`: to specify valid JSON as output (default value: true)
 
 examples :
 
@@ -152,6 +153,12 @@ If you need to disable the colors:
   jsome.params.colored = false;
 ```
 
+If you need JSON which pases linting:
+
+```javascript
+  jsome.params.lintable = true;
+```
+
 When you have a very long json to display, don't make your code blocking... you can enable the asynchronous mode.
 
 ```javascript
@@ -168,6 +175,7 @@ The default value of `params` is:
   jsome.params = {
       'colored' : true
     , 'async'   : false
+    , 'lintable': false
   }
 ```
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -21,15 +21,21 @@ var argv = require('yargs')
     , default   : 2
     , describe  : 'specifying tabulation spaces'
     , type      : 'number'
-  })
+  }).option('r',{
+      alias     : 'lintable'
+    , default   : false
+    , describe  : 'output valid json'
+    , type      : 'boolean'
+})
   .example('jsome -cl /some/dir/file.json', 'print out the content of file.json in color displaying indentation levels')
   .example('jsome -c false -l /some/dir/file.json', 'print out the content of file.json without color but with indentation levels')
   .help('h')
   .argv;
 
-jsome.params.colored = argv.c;
-jsome.level.show     = argv.l;
-jsome.level.spaces   = argv.s;
+jsome.params.colored  = argv.c;
+jsome.params.lintable = argv.r;
+jsome.level.show      = argv.l;
+jsome.level.spaces    = argv.s;
 
 var filePath = argv._[0] || '';
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -73,7 +73,13 @@ module.exports = (function () {
   }
   
   function colorifySpec (char, type, level) {
-    return generateLevel(level) + useColorProvider('' + char, jsomeRef.colors[type]);
+    var quote = (
+      jsomeRef.params.lintable && type === 'attr'
+        ? colorifySpec('"', 'quot', 0)
+        : ''
+    )
+    return generateLevel(level) + quote
+      + useColorProvider('' + char, jsomeRef.colors[type]) + quote;
   }
   
   function useColorProvider (str, color) {

--- a/package.json
+++ b/package.json
@@ -32,5 +32,15 @@
   },
   "bin": {
     "jsome": "./bin/cli.js"
+  },
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^21.2.1",
+    "jsesc": "^2.5.1"
+  },
+  "jest": {
+    "testEnvironment": "node"
   }
 }

--- a/script.js
+++ b/script.js
@@ -22,6 +22,7 @@ var colors = {
 , params = {
     'colored' : true
   , 'async'   : false
+  , 'lintable': false
 }
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,36 @@
+var assert = require('assert'),
+  mJsome = require('../script.js'),
+  escp = require('./helper').escp,
+  chalk = require('chalk'),
+  enc = require('jsesc'),
+  y = chalk.yellow,
+  g = chalk.green,
+  m = chalk.magenta
+
+describe('Jsome', function () {
+
+  describe('integration', function () {
+    describe('simple-colored', function () {
+      var expected = y('{') +
+        '\n  ' + g('string') + y(': ') + y('"') + m('value') + y('"') +
+        y(',') +
+        '\n  ' + g('list') + y(': ') + y('[') + y('"') + m('one') + y('"') +
+        y(', ') + y('"') + m('two') +
+        y('"') + y(']') +
+        '\n' + y('}')
+      var actual = mJsome.getColoredString(
+        {'string': 'value', 'list': ['one', 'two']}
+      )
+
+      test('should return a simple json string', function () {
+        assert.equal(actual, expected)
+      })
+
+      test('should return a simple ANSI escaped json string', function () {
+        assert.equal(enc(actual), enc(expected))
+      })
+
+    })
+  })
+
+})

--- a/test/test.js
+++ b/test/test.js
@@ -8,8 +8,8 @@ var assert = require('assert'),
 
 describe('Jsome', function () {
 
-  describe('integration', function () {
-    describe('simple-colored', function () {
+  describe('run with', function () {
+    describe('spec non-compliant coloured output', function () {
       var expected = y('{') +
         '\n  ' + g('string') + y(': ') + y('"') + m('value') + y('"') +
         y(',') +
@@ -21,15 +21,42 @@ describe('Jsome', function () {
         {'string': 'value', 'list': ['one', 'two']}
       )
 
-      test('should return a simple json string', function () {
+      test('should return a simple non-standard json string', function () {
         assert.equal(actual, expected)
       })
 
-      test('should return a simple ANSI escaped json string', function () {
-        assert.equal(enc(actual), enc(expected))
-      })
+      test('should return a simple non-standard ANSI escaped, json string',
+        function () {
+          assert.equal(enc(actual), enc(expected))
+        })
 
     })
+
+    describe('spec compliant coloured output', function () {
+      var expected = y('{') +
+        '\n  ' + y('"') + g('string') + y('"') + y(': ') + y('"') + m('value') +
+        y('"') +
+        y(',') +
+        '\n  ' + y('"') + g('list') + y('"') + y(': ') + y('[') + y('"') +
+        m('one') + y('"') +
+        y(', ') + y('"') + m('two') +
+        y('"') + y(']') +
+        '\n' + y('}')
+      mJsome.params.lintable = true
+      var actual = mJsome.getColoredString(
+        {'string': 'value', 'list': ['one', 'two']}
+      )
+
+      test('should return a simple non-standard json string', function () {
+        assert.equal(actual, expected)
+      })
+
+      test('should return a simple non-standard ANSI escaped, json string',
+        function () {
+          assert.equal(enc(actual), enc(expected))
+        })
+    })
+
   })
 
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 var assert = require('assert'),
-  mJsome = require('../script.js'),
+  jsome = require('../script.js'),
   chalk = require('chalk'),
   enc = require('jsesc'),
   y = chalk.yellow,
@@ -16,7 +16,7 @@ describe('Jsome run with', function () {
       y(', ') + y('"') + m('two') +
       y('"') + y(']') +
       '\n' + y('}')
-    var actual = mJsome.getColoredString(
+    var actual = jsome.getColoredString(
       {'string': 'value', 'list': ['one', 'two']}
     )
 
@@ -41,8 +41,8 @@ describe('Jsome run with', function () {
       y(', ') + y('"') + m('two') +
       y('"') + y(']') +
       '\n' + y('}')
-    mJsome.params.lintable = true
-    var actual = mJsome.getColoredString(
+    jsome.params.lintable = true
+    var actual = jsome.getColoredString(
       {'string': 'value', 'list': ['one', 'two']}
     )
 
@@ -55,5 +55,5 @@ describe('Jsome run with', function () {
         assert.equal(enc(actual), enc(expected))
       })
   })
-  
+
 })

--- a/test/test.js
+++ b/test/test.js
@@ -6,57 +6,54 @@ var assert = require('assert'),
   g = chalk.green,
   m = chalk.magenta
 
-describe('Jsome', function () {
+describe('Jsome run with', function () {
 
-  describe('run with', function () {
-    describe('spec non-compliant coloured output', function () {
-      var expected = y('{') +
-        '\n  ' + g('string') + y(': ') + y('"') + m('value') + y('"') +
-        y(',') +
-        '\n  ' + g('list') + y(': ') + y('[') + y('"') + m('one') + y('"') +
-        y(', ') + y('"') + m('two') +
-        y('"') + y(']') +
-        '\n' + y('}')
-      var actual = mJsome.getColoredString(
-        {'string': 'value', 'list': ['one', 'two']}
-      )
+  describe('spec non-compliant coloured output', function () {
+    var expected = y('{') +
+      '\n  ' + g('string') + y(': ') + y('"') + m('value') + y('"') +
+      y(',') +
+      '\n  ' + g('list') + y(': ') + y('[') + y('"') + m('one') + y('"') +
+      y(', ') + y('"') + m('two') +
+      y('"') + y(']') +
+      '\n' + y('}')
+    var actual = mJsome.getColoredString(
+      {'string': 'value', 'list': ['one', 'two']}
+    )
 
-      test('should return a simple non-standard json string', function () {
-        assert.equal(actual, expected)
-      })
-
-      test('should return a simple non-standard ANSI escaped, json string',
-        function () {
-          assert.equal(enc(actual), enc(expected))
-        })
-
+    test('should return a simple non-standard json string', function () {
+      assert.equal(actual, expected)
     })
 
-    describe('spec compliant coloured output', function () {
-      var expected = y('{') +
-        '\n  ' + y('"') + g('string') + y('"') + y(': ') + y('"') + m('value') +
-        y('"') +
-        y(',') +
-        '\n  ' + y('"') + g('list') + y('"') + y(': ') + y('[') + y('"') +
-        m('one') + y('"') +
-        y(', ') + y('"') + m('two') +
-        y('"') + y(']') +
-        '\n' + y('}')
-      mJsome.params.lintable = true
-      var actual = mJsome.getColoredString(
-        {'string': 'value', 'list': ['one', 'two']}
-      )
-
-      test('should return a simple non-standard json string', function () {
-        assert.equal(actual, expected)
+    test('should return a simple non-standard ANSI escaped, json string',
+      function () {
+        assert.equal(enc(actual), enc(expected))
       })
-
-      test('should return a simple non-standard ANSI escaped, json string',
-        function () {
-          assert.equal(enc(actual), enc(expected))
-        })
-    })
 
   })
 
+  describe('spec compliant coloured output', function () {
+    var expected = y('{') +
+      '\n  ' + y('"') + g('string') + y('"') + y(': ') + y('"') + m('value') +
+      y('"') +
+      y(',') +
+      '\n  ' + y('"') + g('list') + y('"') + y(': ') + y('[') + y('"') +
+      m('one') + y('"') +
+      y(', ') + y('"') + m('two') +
+      y('"') + y(']') +
+      '\n' + y('}')
+    mJsome.params.lintable = true
+    var actual = mJsome.getColoredString(
+      {'string': 'value', 'list': ['one', 'two']}
+    )
+
+    test('should return a simple non-standard json string', function () {
+      assert.equal(actual, expected)
+    })
+
+    test('should return a simple non-standard ANSI escaped, json string',
+      function () {
+        assert.equal(enc(actual), enc(expected))
+      })
+  })
+  
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,5 @@
 var assert = require('assert'),
   mJsome = require('../script.js'),
-  escp = require('./helper').escp,
   chalk = require('chalk'),
   enc = require('jsesc'),
   y = chalk.yellow,


### PR DESCRIPTION
As mentioned in #12, when passing the output of `jsome(...)` into a utility which expects validate JSON (for example,` jq`) or a JSON linter, errors are thrown as keys are expected to bring wrapped in double quotes as per the JSON spec (members have pairs; pairs have strings on the left size of : and strings have " around them).

This adds quotes is `jsome.params.lintable` is set to true, and added a cli option for the cli util.