### PR TITLE
print object keys in sorted order

### DIFF
--- a/lib/generator.js
+++ b/lib/generator.js
@@ -108,17 +108,20 @@ module.exports = (function () {
       
       if (isObject(json)) {
         
-        var lastKey = cleanObject(json);
+        cleanObject(json);
+        var keys = Object.keys(json).sort();
         colored.push(colorifySpec('{', 'brack', isChild ? 0 : level)); 
         level++;
         
-        for(var key in json) {
+        var that = this;
+
+        keys.forEach( function (key,i) {
           var result = colorifySpec(key, 'attr', level) 
              + colorifySpec(': ', 'punc') 
-             + this.gen(json[key], level, true) 
-             + (key !== lastKey ? colorifySpec(',', 'punc') : '');
+             + that.gen(json[key], level, true) 
+             + (i !== (keys.length-1) ? colorifySpec(',', 'punc') : '');
           colored.push(result);
-        }
+        });
         
         colored.push(colorifySpec('}', 'brack', --level));
         


### PR DESCRIPTION
Since keys in JSON objects are specified to be unordered, it's legal to print them in any order.

For pretty-printing purposes, it's nice to have them sorted. This simplifies tasks like looking for a particular key in the output and visually comparing two pretty-printed objects.

Let me know what you think!

Thanks,
-John