### PR TITLE
Display long arrays in a multiline representation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The options available are :
 - `-l`: to enable or disable levels (default value: false)
 - `-s`: to specify the number of tabulation spaces (default value: 2)
 - `-r`: to specify valid JSON as output (default value: true)
+- `-m`: to specify the max inline representetion length of an array (default value: 80)
 
 examples :
 
@@ -165,6 +166,12 @@ If you need JSON which pases linting:
   jsome.params.lintable = true;
 ```
 
+If you need to change the max length of an inline representetion of an array
+
+```javascript
+  jsome.params.maxInlineLength = 30;
+```
+
 When you have a very long json to display, don't make your code blocking... you can enable the asynchronous mode.
 
 ```javascript
@@ -182,6 +189,7 @@ The default value of `params` is:
       'colored' : true
     , 'async'   : false
     , 'lintable': false
+    , 'maxInlineLength': 80
   }
 ```
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -26,6 +26,11 @@ var argv = require('yargs')
     , default   : false
     , describe  : 'output valid json'
     , type      : 'boolean'
+  }).option('m', {
+      alias     : 'maxInlineLength'
+    , default   : 80
+    , describe  : 'the max inline representetion length of an array'
+    , type      : 'number'
 })
   .example('jsome -cl /some/dir/file.json', 'print out the content of file.json in color displaying indentation levels')
   .example('jsome -c false -l /some/dir/file.json', 'print out the content of file.json without color but with indentation levels')
@@ -34,6 +39,7 @@ var argv = require('yargs')
 
 jsome.params.colored  = argv.c;
 jsome.params.lintable = argv.r;
+jsome.params.maxInlineLength = argv.m;
 jsome.level.show      = argv.l;
 jsome.level.spaces    = argv.s;
 

--- a/lib/generator.js
+++ b/lib/generator.js
@@ -141,7 +141,16 @@ module.exports = (function () {
           colored.push(result.join(colorifySpec(', ', 'punc') + '\n' ));
           colored.push(colorifySpec(']', 'brack', level));
           
-        } else {
+        } else if (JSON.stringify(json).length > jsomeRef.params.maxInlineLength) { // long array
+
+          colored.push(colorifySpec('[', 'brack', isChild ? 0 : level));
+          level++
+          for (var key in json) {
+            colored.push(this.gen(json[key], level) + (json.length-1>key ? colorifySpec(',', 'punc') : ''));
+          }
+          colored.push(colorifySpec(']', 'brack', --level));
+
+        } else { // small array
           
           var coloredArray = colorifySpec('[', 'brack', isChild ? 0 : level);
           for (var key in json) {

--- a/script.js
+++ b/script.js
@@ -23,6 +23,7 @@ var colors = {
     'colored' : true
   , 'async'   : false
   , 'lintable': false
+  , 'maxInlineLength': 80
 }
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,11 @@ var assert = require('assert'),
 
 describe('Jsome run with', function () {
 
+  beforeEach(function () {
+    jsome.params.colored = true
+    jsome.params.maxInlineLength = 80
+  });
+
   describe('spec non-compliant coloured output', function () {
     var expected = y('{') +
       '\n  ' + g('string') + y(': ') + y('"') + m('value') + y('"') +
@@ -54,6 +59,27 @@ describe('Jsome run with', function () {
       function () {
         assert.equal(enc(actual), enc(expected))
       })
+  })
+
+  describe('decide the better array presentation', function () {
+
+    test('should not line broke a small inline array', function () {
+      jsome.params.colored = false
+      assert.equal(
+        jsome.getColoredString([1234567890, 'ABCDEFGHIJ']),
+        '[1234567890, "ABCDEFGHIJ"]'
+      )
+    })
+
+    test('should broke long inline in a multiline representation', function () {
+      jsome.params.colored = false
+      jsome.params.maxInlineLength = 20
+      assert.equal(
+        jsome.getColoredString([1234567890, 'ABCDEFGHIJ']),
+        '[\n  1234567890,\n  "ABCDEFGHIJ"\n]'
+      )
+    })
+
   })
 
 })


### PR DESCRIPTION
It tests if the inline representation length is bigger than `jsome.params.maxInlineLength`, than do the job.

This commit adds a new cli parameter `-m` to set jsome.params.maxInlineLength.