### PR TITLE
BREAKING CHANGE: Require Node 8+ (and upgrade yargs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 sudo: false
 language: node_js
 node_js:
-  - '4'
-  - '6'
-  - '7'
   - '8'
-  - '9'
+  - '10'
+  - '12'
 before_script: npm link
 script: jsome package.json && cat package.json | jsome && npm test

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "chalk": "^2.3.0",
     "json-stringify-safe": "^5.0.1",
-    "yargs": "^11.0.0"
+    "yargs": "^13.2.4"
   },
   "bin": {
     "jsome": "./bin/cli.js"
@@ -39,6 +39,9 @@
   "devDependencies": {
     "jest": "^21.2.1",
     "jsesc": "^2.5.1"
+  },
+  "engines": {
+    "node": ">= 8"
   },
   "jest": {
     "testEnvironment": "node"


### PR DESCRIPTION
I briefly reviewed the changelogs, and the only relevant thing I found was related to the Node version:

- https://github.com/yargs/yargs/blob/master/CHANGELOG.md
- https://github.com/yargs/yargs-parser/blob/master/CHANGELOG.md#breaking-changes

Node 6 reached end of life earlier this year: https://nodejs.org/en/about/releases/

Closes #20